### PR TITLE
FEATURE: Add raw_response as an optional arg to methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ RSpotify.raw_response = true
 RSpotify::Artist.search('Cher') #=> (String with raw json response)
 ```
 
+Alternatively, pass `raw_response: true` to the individual method you are calling to override the app configuration.
+
 ## Notes
 
 If you'd like to use OAuth outside rails, have a look [here](https://developer.spotify.com/web-api/authorization-guide/#authorization_code_flow) for the requests that need to be made. You should be able to pass the response to RSpotify::User.new just as well, and from there easily create playlists and more for your user.

--- a/lib/rspotify/artist.rb
+++ b/lib/rspotify/artist.rb
@@ -60,25 +60,27 @@ module RSpotify
     # @param offset     [Integer] The index of the first album to return. Use with limit to get the next set of albums. Default: 0.
     # @param album_type [String]  Optional. A comma-separated list of keywords that will be used to filter the response. If not supplied, all album types will be returned. Valid values are: album; single; appears_on; compilation.
     # @param market     [String]  Optional. (synonym: country). An {http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 ISO 3166-1 alpha-2 country code}. Supply this parameter to limit the response to one particular geographical market. If not supplied, results will be returned for all markets. Note if you do not provide this field, you are likely to get duplicate results per album, one for each market in which the album is available.
+    # @param raw_response [Boolean] Whether the return value should be the raw JSON response or parsed into RSpotify models
     # @return [Array<Album>]
     #
     # @example
     #           artist.albums
     #           artist.albums(album_type: 'single,compilation')
     #           artist.albums(limit: 50, country: 'US')
-    def albums(limit: 20, offset: 0, **filters)
+    def albums(limit: 20, offset: 0, raw_response: false, **filters)
       url = "artists/#{@id}/albums?limit=#{limit}&offset=#{offset}"
       filters.each do |filter_name, filter_value|
         url << "&#{filter_name}=#{filter_value}"
       end
 
       response = RSpotify.get(url)
-      return response if RSpotify.raw_response
+      return response if return_raw_response?(raw_response)
       response['items'].map { |i| Album.new i }
     end
 
     # Returns array of similar artists. Similarity is based on analysis of the Spotify community’s {http://news.spotify.com/se/2010/02/03/related-artists listening history}.
     #
+    # @param raw_response [Boolean] Whether the return value should be the raw JSON response or parsed into RSpotify models
     # @return [Array<Artist>]
     #
     # @example
@@ -87,17 +89,18 @@ module RSpotify
     #
     #           related_artists.size       #=> 20
     #           related_artists.first.name #=> "Miles Kane"
-    def related_artists
-      return @related_artists unless @related_artists.nil? || RSpotify.raw_response
+    def related_artists(raw_response: false)
+      return @related_artists unless @related_artists.nil? || return_raw_response?(raw_response)
       response = RSpotify.get("artists/#{@id}/related-artists")
 
-      return response if RSpotify.raw_response
+      return response if return_raw_response?(raw_response)
       @related_artists = response['artists'].map { |a| Artist.new a }
     end
 
     # Returns artist's 10 top tracks by country.
     #
     # @param country [Symbol] An {http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 ISO 3166-1 alpha-2 country code}
+    # @param raw_response [Boolean] Whether the return value should be the raw JSON response or parsed into RSpotify models
     # @return [Array<Track>]
     #
     # @example
@@ -105,11 +108,11 @@ module RSpotify
     #           top_tracks.class       #=> Array
     #           top_tracks.size        #=> 10
     #           top_tracks.first.class #=> RSpotify::Track
-    def top_tracks(country)
-      return @top_tracks[country] unless @top_tracks[country].nil? || RSpotify.raw_response
+    def top_tracks(country, raw_response: false)
+      return @top_tracks[country] unless @top_tracks[country].nil? || return_raw_response?(raw_response)
       response = RSpotify.get("artists/#{@id}/top-tracks?country=#{country}")
 
-      return response if RSpotify.raw_response
+      return response if return_raw_response?(raw_response)
       @top_tracks[country] = response['tracks'].map { |t| Track.new t }
     end
   end

--- a/lib/rspotify/audio_features.rb
+++ b/lib/rspotify/audio_features.rb
@@ -20,23 +20,24 @@ module RSpotify
     # Retrieves AudioFeatures object(s) for the track id(s) provided
     #
     # @param ids [String, Array] Either a single track id or a list track ids. Maximum: 100 IDs.
+    # @param raw_response [Boolean] Whether the return value should be the raw JSON response or parsed into RSpotify models
     # @return [AudioFeatures, Array<AudioFeatures>]
     #
     # @example
     #           audio_features = RSpotify::AudioFeatures.find('1zHlj4dQ8ZAtrayhuDDmkY')
     #           audio_features = RSpotify::AudioFeatures.find(['1zHlj4dQ8ZAtrayhuDDmkY', '7ouMYWpwJ422jRcDASZB7P', '4VqPOruhp5EdPBeR92t6lQ'])
-    def self.find(ids)
+    def self.find(ids, raw_response: false)
       case ids
       when Array
         url = "audio-features?ids=#{ids.join(',')}"
         response = RSpotify.get(url)
-        return response if RSpotify.raw_response
+        return response if return_raw_response?(raw_response)
 
         response['audio_features'].map { |i| i.nil? ? nil : AudioFeatures.new(i) }
       when String
         url = "audio-features/#{ids}"
         response = RSpotify.get(url)
-        return response if RSpotify.raw_response
+        return response if return_raw_response?(raw_response)
 
         AudioFeatures.new response
       end

--- a/lib/rspotify/base.rb
+++ b/lib/rspotify/base.rb
@@ -116,6 +116,10 @@ module RSpotify
       result
     end
 
+    def self.return_raw_response?(raw_response)
+      RSpotify.raw_response || raw_response
+    end
+
     def initialize(options = {})
       @external_urls = options['external_urls']
       @href          = options['href']
@@ -207,7 +211,7 @@ module RSpotify
     end
 
     def return_raw_response?(raw_response)
-      RSpotify.raw_response || raw_response
+      self.class.return_raw_response?(raw_response)
     end
 
     protected

--- a/lib/rspotify/base.rb
+++ b/lib/rspotify/base.rb
@@ -37,24 +37,24 @@ module RSpotify
       end
     end
 
-    def self.find_many(ids, type, market: nil)
+    def self.find_many(ids, type, market: nil, raw_response: false)
       type_class = RSpotify.const_get(type.capitalize)
       path = "#{type}s?ids=#{ids.join ','}"
       path << "&market=#{market}" if market
 
       response = RSpotify.get path
-      return response if RSpotify.raw_response
+      return response if return_raw_response?(raw_response)
       response["#{type}s"].map { |t| type_class.new t if t }
     end
     private_class_method :find_many
 
-    def self.find_one(id, type, market: nil)
+    def self.find_one(id, type, market: nil, raw_response: false)
       type_class = RSpotify.const_get(type.capitalize)
       path = "#{type}s/#{id}"
       path << "?market=#{market}" if market
 
       response = RSpotify.get path
-      return response if RSpotify.raw_response
+      return response if return_raw_response?(raw_response)
       type_class.new response unless response.nil?
     end
     private_class_method :find_one
@@ -79,6 +79,7 @@ module RSpotify
     # @param limit  [Integer]      Maximum number of objects to return. Maximum: 50. Default: 20.
     # @param offset [Integer]      The index of the first object to return. Use with limit to get the next set of objects. Default: 0.
     # @param market [String, Hash] Optional. An {http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 ISO 3166-1 alpha-2 country code} or the hash { from: user }, where user is a RSpotify user authenticated using OAuth with scope *user-read-private*. This will take the user's country as the market value. (Playlist results are not affected by the market parameter.) For details access {https://developer.spotify.com/web-api/search-item here} and look for the market parameter description.
+    # @param raw_response [Boolean] Whether the return value should be the raw JSON response or parsed into RSpotify models
     # @return [Array<Album>, Array<Artist>, Array<Track>, Array<Playlist>, Array<Base>]
     #
     # @example
@@ -88,7 +89,7 @@ module RSpotify
     #           albums  = RSpotify::Base.search('AM', 'album', market: { from: user })
     #
     #           RSpotify::Base.search('Arctic', 'album,artist,playlist').total #=> 2142
-    def self.search(query, types, limit: 20, offset: 0, market: nil)
+    def self.search(query, types, limit: 20, offset: 0, market: nil, raw_response: false)
       query = CGI.escape query
       types.gsub!(/\s+/, '')
 
@@ -103,7 +104,7 @@ module RSpotify
         RSpotify.get(url)
       end
 
-      return response if RSpotify.raw_response
+      return response if return_raw_response?(raw_response)
 
       types = types.split(',')
       result = types.flat_map do |type|
@@ -203,6 +204,10 @@ module RSpotify
       attr = "@#{method_name}"
       return super if method_name.match(/[\?!]$/) || !instance_variable_defined?(attr)
       true
+    end
+
+    def return_raw_response?(raw_response)
+      RSpotify.raw_response || raw_response
     end
 
     protected

--- a/lib/rspotify/category.rb
+++ b/lib/rspotify/category.rb
@@ -14,13 +14,14 @@ module RSpotify
     # @param id      [String] The {https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids Spotify ID} of the category
     # @param country [String] Optional. A country: an {http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 ISO 3166-1 alpha-2 country code}. Provide this parameter to ensure that the category exists for a particular country.
     # @param locale  [String] Optional. The desired language, consisting of a lowercase {http://en.wikipedia.org/wiki/ISO_639 ISO 639 language code} and an uppercase {http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 ISO 3166-1 alpha-2 country code}, joined by an underscore. For details access {https://developer.spotify.com/web-api/get-category/ here} and look for the locale parameter description.
+    # @param raw_response [Boolean] Whether the return value should be the raw JSON response or parsed into RSpotify models
     # @return [Category]
     #
     # @example
     #           category = RSpotify::Category.find('party')
     #           category = RSpotify::Category.find('party', country: 'US')
     #           category = RSpotify::Category.find('party', locale: 'es_MX')
-    def self.find(id, **options)
+    def self.find(id, raw_response: false, **options)
       url = "browse/categories/#{id}"
       url << '?' if options.any?
 
@@ -30,7 +31,7 @@ module RSpotify
       end
 
       response = RSpotify.get(url)
-      return response if RSpotify.raw_response
+      return response if return_raw_response?(raw_response)
       Category.new response
     end
 
@@ -40,20 +41,21 @@ module RSpotify
     # @param offset [Integer] Optional. The index of the first category to return. Use with limit to get the next set of categories. Default: 0.
     # @param country [String] Optional. A country: an {http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 ISO 3166-1 alpha-2 country code}. Provide this parameter if you want to narrow the list of returned categories to those relevant to a particular country. If omitted, the returned categories will be globally relevant.
     # @param locale  [String] Optional. The desired language, consisting of a lowercase {http://en.wikipedia.org/wiki/ISO_639 ISO 639 language code} and an uppercase {http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 ISO 3166-1 alpha-2 country code}, joined by an underscore. For details access {https://developer.spotify.com/web-api/get-category/ here} and look for the locale parameter description.
+    # @param raw_response [Boolean] Whether the return value should be the raw JSON response or parsed into RSpotify models
     # @return [Array<Category>]
     #
     # @example
     #           categories = RSpotify::Category.list
     #           categories = RSpotify::Category.list(country: 'US')
     #           categories = RSpotify::Category.list(locale: 'es_MX', limit: 10)
-    def self.list(limit: 20, offset: 0, **options)
+    def self.list(limit: 20, offset: 0, raw_response: false, **options)
       url = "browse/categories?limit=#{limit}&offset=#{offset}"
       options.each do |option, value|
         url << "&#{option}=#{value}"
       end
 
       response = RSpotify.get(url)
-      return response if RSpotify.raw_response
+      return response if return_raw_response?(raw_response)
       response['categories']['items'].map { |i| Category.new i }
     end
 
@@ -80,13 +82,14 @@ module RSpotify
     # @param limit  [Integer] Maximum number of playlists to return. Maximum: 50. Default: 20.
     # @param offset [Integer] The index of the first playlist to return. Use with limit to get the next set of playlists. Default: 0.
     # @param country [String] Optional. A country: an {http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 ISO 3166-1 alpha-2 country code}. Provide this parameter if you want to narrow the list of returned playlists to those relevant to a particular country. If omitted, the returned playlists will be globally relevant.
+    # @param raw_response [Boolean] Whether the return value should be the raw JSON response or parsed into RSpotify models
     # @return [Array<Playlist>]
     #
     # @example
     #           playlists = category.playlists
     #           playlists = category.playlists(country: 'BR')
     #           playlists = category.playlists(limit: 10, offset: 20)
-    def playlists(limit: 20, offset: 0, **options)
+    def playlists(limit: 20, offset: 0, raw_response: false, **options)
       url = "browse/categories/#{@id}/playlists"\
             "?limit=#{limit}&offset=#{offset}"
 
@@ -95,7 +98,7 @@ module RSpotify
       end
 
       response = RSpotify.get(url)
-      return response if RSpotify.raw_response
+      return response if return_raw_response?(raw_response)
       response['playlists']['items'].map { |i| Playlist.new i }
     end
   end

--- a/lib/rspotify/player.rb
+++ b/lib/rspotify/player.rb
@@ -168,10 +168,10 @@ module RSpotify
       User.oauth_put(@user.id, url, {})
     end
 
-    def currently_playing
+    def currently_playing(raw_response: false)
       url = "me/player/currently-playing"
       response = RSpotify.resolve_auth_request(@user.id, url)
-      return response if RSpotify.raw_response
+      return response if return_raw_response?(raw_response)
       Track.new response["item"]
     end
 

--- a/lib/rspotify/recommendations.rb
+++ b/lib/rspotify/recommendations.rb
@@ -5,13 +5,14 @@ module RSpotify
   class Recommendations < Base
     
     # Retrieve a list of available genres seed parameter values for recommendations. 
+    # @param raw_response [Boolean] Whether the return value should be the raw JSON response or parsed into RSpotify models
     # @return [Array<String>] 
     #
     # @example
     #          genres = RSpotify::Recommendations.available_genre_seeds
-    def self.available_genre_seeds
+    def self.available_genre_seeds(raw_response: false)
       response = RSpotify.get('recommendations/available-genre-seeds')
-      return response if RSpotify.raw_response
+      return response if return_raw_response?(raw_response)
 
       response['genres']
     end
@@ -25,6 +26,7 @@ module RSpotify
     # @param seed_genres  [Array<String>] A list of any genres in the set of {https://developer.spotify.com/web-api/get-recommendations/#available-genre-seeds available genre seeds}.
     # @param seed_tracks  [Array<String>] A list of Spotify IDs for seed tracks.
     # @param market       [String]        Optional. An {https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2  ISO 3166-1 alpha-2 country code}. Provide this parameter if you want to apply Track Relinking. Because min_*, max_* and target_* are applied to pools before relinking, the generated results may not precisely match the filters applied. Original, non-relinked tracks are available via the linked_from attribute of the relinked track response.
+    # @param raw_response [Boolean] Whether the return value should be the raw JSON response or parsed into RSpotify models
     # @option options     [Float]         :min_acousticness Hard floor on the confidence measure from 0.0 to 1.0 of whether the track is acoustic. 1.0 represents high confidence the track is acoustic.          
     # @option options     [Float]         :max_acousticness Hard ceiling on the confidence measure from 0.0 to 1.0 of whether the track is acoustic. 1.0 represents high confidence the track is acoustic. 
     # @option options     [Float]         :target_acousticness Target value on the confidence measure from 0.0 to 1.0 of whether the track is acoustic. 1.0 represents high confidence the track is acoustic.
@@ -73,7 +75,7 @@ module RSpotify
     #          recommendations = RSpotify::Recommendations.generate(limit: 20, seed_tracks: ['0c6xIDDpzE81m2q797ordA'])
     #          recommendations = RSpotify::Recommendations.generate(seed_tracks: ['0c6xIDDpzE81m2q797ordA'], seed_artists: ['4NHQUGzhtTLFvgF5SZesLK'], market: 'ES')
     #          recommendations = RSpotify::Recommendations.generate(seed_tracks: ['0c6xIDDpzE81m2q797ordA'], seed_genres: ['alt_rock'], seed_artists: ['4NHQUGzhtTLFvgF5SZesLK'], target_energy: 1.0)
-    def self.generate(limit: 20, seed_artists: [], seed_genres: [], seed_tracks: [], market: nil, **options)
+    def self.generate(limit: 20, seed_artists: [], seed_genres: [], seed_tracks: [], market: nil, raw_response: false, **options)
       url = "recommendations?limit=#{limit}"
 
       url << "&seed_artists=#{seed_artists.join(',')}" if seed_artists.any?
@@ -92,7 +94,7 @@ module RSpotify
         RSpotify.get(url)
       end
 
-      return response if RSpotify.raw_response
+      return response if return_raw_response?(raw_response)
 
       Recommendations.new response
     end

--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -342,9 +342,8 @@ module RSpotify
       url = "me/tracks?limit=#{limit}&offset=#{offset}"
       url << "&market=#{market}" if market
       response = User.oauth_get(@id, url)
-      json = return_raw_response?(raw_response) ? JSON.parse(response) : response
 
-      tracks = json['items'].select { |i| i['track'] }
+      tracks = response['items'].select { |i| i['track'] }
       @tracks_added_at = hash_for(tracks, 'added_at') do |added_at|
         Time.parse added_at
       end


### PR DESCRIPTION
Instead of relying on thread-unsafe class instance variables to control `RSpotify.raw_response`, this updates all methods with the potential to return a raw response.  `raw_response: true` can now be passed as an optional argument to toggle between parsed RSpotify models and JSON responses on a per-call basis.