### PR TITLE
FEATURE: Add tracks in request body not url

### DIFF
--- a/lib/rspotify/playlist.rb
+++ b/lib/rspotify/playlist.rb
@@ -156,14 +156,17 @@ module RSpotify
     def add_tracks!(tracks, position: nil, raw_response: false)
       track_uris = nil
       if tracks.first.is_a? String
-        track_uris = tracks.join(',')
+        track_uris = tracks
       else
-        track_uris = tracks.map(&:uri).join(',')
+        track_uris = tracks.map(&:uri)
       end
-      url = "#{@path}/tracks?uris=#{track_uris}"
-      url << "&position=#{position}" if position
+      url = "#{@href}/tracks"
+      params = {
+        uris: tracks
+      }
+      params.merge!(position: position) if position
 
-      response = User.oauth_post(@owner.id, url, {}.to_json)
+      response = User.oauth_post(@owner.id, url, params.to_json)
       @total += tracks.size
       @tracks_cache = nil
 


### PR DESCRIPTION
Optimizes this gem for adding a lot of tracks to a playlist at once. Since long strings of URIs must be passed, it is possible to raise errors by reaching the maximum length for urls with the tracks in query params. It's much more stable to pass tracks in the body, per the Spotify documentation: https://developer.spotify.com/documentation/web-api/reference/#/operations/add-tracks-to-playlist