### PR TITLE
FEATURE: Allow deleting tracks from playlist with uri

### DIFF
--- a/lib/rspotify/episode.rb
+++ b/lib/rspotify/episode.rb
@@ -34,7 +34,7 @@ module RSpotify
     #           episodes.class       #=> Array
     #           episodes.first.class #=> RSpotify::Episode
     def self.find(ids, market: nil, raw_response: false)
-      super(ids, 'episode', market: market, raw_response)
+      super(ids, 'episode', market: market, raw_response: raw_response)
     end
 
     # Returns array of Episode objects matching the query. It's also possible to find the total number of search results for the query

--- a/lib/rspotify/playlist.rb
+++ b/lib/rspotify/playlist.rb
@@ -293,7 +293,7 @@ module RSpotify
     # Remove one or more tracks from a user’s playlist. Removing from a public playlist requires the
     # *playlist-modify-public* scope; removing from a private playlist requires the *playlist-modify-private* scope.
     #
-    # @param tracks [Array<Track,Hash>, Array<Integer>] Tracks to be removed. Maximum: 100 per request
+    # @param tracks [Array<Track,Hash>, Array<Integer>, Array<String>] Tracks to be removed. Maximum: 100 per request
     # @param snapshot_id [String] Optional. The playlist's snapshot ID against which you want to make the changes.
     # @return [Playlist]
     #
@@ -314,6 +314,7 @@ module RSpotify
 
       tracks = tracks.map do |track|
         next { uri: track.uri } if track.is_a? Track
+        next { uri: track } if track.is_a? String
         {
           uri: track[:track].uri,
           positions: track[:positions]


### PR DESCRIPTION
The Spotify API accepts track URIs as a parameter to delete tracks from a playlist, so let the RSpotify method `#remove_tracks!` accept URIs without the full Track object.